### PR TITLE
Dockerfile_v5.5.0 used for dockerhub update

### DIFF
--- a/Dockerfile_v5.5.0
+++ b/Dockerfile_v5.5.0
@@ -1,0 +1,27 @@
+
+# Install anaconda Python stack and some other useful tools
+FROM continuumio/anaconda
+RUN apt-get update
+RUN apt-get install -y tar git curl wget dialog net-tools build-essential
+
+# Install editors:
+RUN apt-get install -y vim nano
+
+# Install gfortran
+RUN apt-get install -y gfortran
+
+# Install clawpack-v5.5.0:
+RUN pip install --src=/ --user -e git+https://github.com/clawpack/clawpack.git@v5.5.0#egg=clawpack-v5.5.0
+
+# Set environment variables:
+RUN echo 'export CLAW=/clawpack-v5.5.0' >> ~/.bashrc
+RUN echo 'export FC=gfortran' >> ~/.bashrc
+
+# Download the master branch of the apps repository and rename:
+# (You can change `master` to a commit hash for a different version)
+RUN curl -sL https://github.com/clawpack/apps/archive/128e289c43b.tar.gz | tar xz
+RUN mv apps-* /clawpack-v5.5.0/apps
+
+# Additional Python packages
+RUN pip install plotly
+


### PR DESCRIPTION
I forgot to push this after updating dockerhub back in August 2018.

We should also update for netCDF version as done by @bolliger32 in #4.  Should we include that in general in the primary Dockerfile or best to keep separate since most users don't use netCDF?