### PR TITLE
V5.6.1 updates

### DIFF
--- a/Dockerfile_v5.6.1
+++ b/Dockerfile_v5.6.1
@@ -1,36 +1,29 @@
 # Install anaconda Python stack and some other useful tools
-FROM continuumio/anaconda3
-RUN apt-get update
-RUN apt-get install -y tar git curl wget dialog net-tools build-essential
+FROM jupyter/base-notebook
 
-# set conda-forge as priority conda repository
-RUN conda config --add channels conda-forge
-
-# Set up user jovyan so this image can be used e.g. on mybinder.org
-ENV NB_USER jovyan
-ENV NB_UID 1000
-ENV HOME /home/${NB_USER}
-
-## Add NB_USER to sudo
 USER root
-RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
-RUN sed -ri "s#Defaults\s+secure_path=\"([^\"]+)\"#Defaults secure_path=\"\1:$CONDA_DIR/bin\"#" /etc/sudoers
-USER $NB_USER
-
-RUN adduser --disabled-password \
-    --gecos "Default user" \
-    --uid ${NB_UID} \
-    ${NB_USER}
-
-USER ${NB_USER}
+RUN apt-get update && \
+  apt-get install -y dialog net-tools build-essential
+USER jovyan
 
 # Install gfortran and editors
-RUN conda install -y -c conda-forge compilers vim nano
+RUN conda install -y -c conda-forge \
+  scipy \
+  compilers \
+  lapack \
+  vim \
+  nano \
+  git \
+  tar \
+  curl \
+  nose
 
 # set env variables
 ENV CLAW ${HOME}/clawpack-v5.6.1
 ENV NETCDF4_DIR /opt/conda
 ENV FC gfortran
+# this is needed to find libraries when building geoclaw (particularly lapack)
+ENV LIB_PATHS /opt/conda/lib
 
 # Install clawpack-v5.6.1:
 RUN pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.6.1#egg=clawpack-v5.6.1

--- a/Dockerfile_v5.6.1
+++ b/Dockerfile_v5.6.1
@@ -1,0 +1,44 @@
+
+# Install anaconda Python stack and some other useful tools
+FROM continuumio/anaconda
+RUN apt-get update
+RUN apt-get install -y tar git curl wget dialog net-tools build-essential
+
+# Install editors:
+RUN apt-get install -y vim nano
+
+# Install gfortran
+RUN apt-get install -y gfortran
+
+
+# Set up user jovyan so this image can be used e.g. on mybinder.org
+ENV NB_USER jovyan
+ENV NB_UID 1000
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+
+USER ${NB_USER}
+
+# Install clawpack-v5.6.1:
+RUN pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.6.1#egg=clawpack-v5.6.1
+
+ENV CLAW ${HOME}/clawpack-v5.6.1
+
+# Put environment variables commands into .bashrc:
+RUN echo 'export CLAW=${CLAW}' >> ~/.bashrc
+RUN echo 'export FC=gfortran' >> ~/.bashrc
+# set prompt:
+RUN echo 'export PS1="jovyan $ "' >> ~/.bashrc
+
+WORKDIR ${CLAW}
+# Download the master branch of the apps repository and rename:
+# (You can change `master` to a commit hash for a different version)
+RUN curl -sL https://github.com/clawpack/apps/archive/master.tar.gz | tar xz
+RUN mv apps-* apps
+
+WORKDIR ${HOME}
+

--- a/Dockerfile_v5.6.1
+++ b/Dockerfile_v5.6.1
@@ -1,15 +1,10 @@
-
 # Install anaconda Python stack and some other useful tools
-FROM continuumio/anaconda
+FROM continuumio/anaconda3
 RUN apt-get update
 RUN apt-get install -y tar git curl wget dialog net-tools build-essential
 
-# Install editors:
-RUN apt-get install -y vim nano
-
-# Install gfortran
-RUN apt-get install -y gfortran
-
+# set conda-forge as priority conda repository
+RUN conda config --add channels conda-forge
 
 # Set up user jovyan so this image can be used e.g. on mybinder.org
 ENV NB_USER jovyan
@@ -23,14 +18,17 @@ RUN adduser --disabled-password \
 
 USER ${NB_USER}
 
+# Install gfortran and editors
+RUN conda install -y -c conda-forge compilers vim nano
+
+# set env variables
+ENV CLAW ${HOME}/clawpack-v5.6.1
+ENV NETCDF4_DIR /opt/conda
+ENV FC gfortran
+
 # Install clawpack-v5.6.1:
 RUN pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.6.1#egg=clawpack-v5.6.1
 
-ENV CLAW ${HOME}/clawpack-v5.6.1
-
-# Put environment variables commands into .bashrc:
-RUN echo 'export CLAW=${CLAW}' >> ~/.bashrc
-RUN echo 'export FC=gfortran' >> ~/.bashrc
 # set prompt:
 RUN echo 'export PS1="jovyan $ "' >> ~/.bashrc
 
@@ -41,4 +39,3 @@ RUN curl -sL https://github.com/clawpack/apps/archive/master.tar.gz | tar xz
 RUN mv apps-* apps
 
 WORKDIR ${HOME}
-

--- a/Dockerfile_v5.6.1
+++ b/Dockerfile_v5.6.1
@@ -38,3 +38,4 @@ RUN curl -sL https://github.com/clawpack/apps/archive/master.tar.gz | tar xz
 RUN mv apps-* apps
 
 WORKDIR ${HOME}
+CMD [ "/bin/bash" ]

--- a/Dockerfile_v5.6.1
+++ b/Dockerfile_v5.6.1
@@ -11,6 +11,12 @@ ENV NB_USER jovyan
 ENV NB_UID 1000
 ENV HOME /home/${NB_USER}
 
+## Add NB_USER to sudo
+USER root
+RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
+RUN sed -ri "s#Defaults\s+secure_path=\"([^\"]+)\"#Defaults secure_path=\"\1:$CONDA_DIR/bin\"#" /etc/sudoers
+USER $NB_USER
+
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \

--- a/Dockerfile_v5.6.1_geoclaw
+++ b/Dockerfile_v5.6.1_geoclaw
@@ -1,0 +1,18 @@
+# Start from the clawpack v5.6.1 image that includes everything already done
+# in Dockerfile_v5.6.1:
+FROM clawpack/v5.6.1_dockerimage:release
+
+# need to be root to install new packages
+USER root
+
+# Install additional packages useful with GeoClaw (not all are st
+RUN conda install -c conda-forge xarray
+RUN conda install -c conda-forge netcdf4
+RUN conda install -c conda-forge cartopy
+RUN conda install -c conda-forge ffmpeg
+RUN conda install -c conda-forge pyproj
+RUN conda install -c conda-forge rasterio
+
+# Start container as this user
+USER jovyan
+    

--- a/Dockerfile_v5.6.1_geoclaw
+++ b/Dockerfile_v5.6.1_geoclaw
@@ -2,8 +2,7 @@
 # in Dockerfile_v5.6.1:
 FROM clawpack/v5.6.1_dockerimage:release
 
-# need to be root to install new packages
-USER root
+USER jovyan
 
 # Install additional packages useful with GeoClaw (not all are st
 RUN conda install -c conda-forge \
@@ -14,6 +13,3 @@ RUN conda install -c conda-forge \
   ffmpeg \
   pyproj \
   rasterio
-
-# Start container as this user
-USER jovyan

--- a/Dockerfile_v5.6.1_geoclaw
+++ b/Dockerfile_v5.6.1_geoclaw
@@ -7,12 +7,12 @@ USER root
 
 # Install additional packages useful with GeoClaw (not all are st
 RUN conda install -c conda-forge \
-  xarray
-  netcdf4
-  netcdf4-fortran
-  cartopy
-  ffmpeg
-  pyproj
+  xarray \
+  netcdf4 \
+  netcdf4-fortran \
+  cartopy \
+  ffmpeg \
+  pyproj \
   rasterio
 
 # Start container as this user

--- a/Dockerfile_v5.6.1_geoclaw
+++ b/Dockerfile_v5.6.1_geoclaw
@@ -4,7 +4,8 @@ FROM clawpack/v5.6.1_dockerimage:release
 
 USER jovyan
 
-# Install additional packages useful with GeoClaw (not all are st
+# Install additional packages useful with GeoClaw
+# netCDF is required for some tests
 RUN conda install -c conda-forge \
   xarray \
   netcdf4 \

--- a/Dockerfile_v5.6.1_geoclaw
+++ b/Dockerfile_v5.6.1_geoclaw
@@ -6,13 +6,14 @@ FROM clawpack/v5.6.1_dockerimage:release
 USER root
 
 # Install additional packages useful with GeoClaw (not all are st
-RUN conda install -c conda-forge xarray
-RUN conda install -c conda-forge netcdf4
-RUN conda install -c conda-forge cartopy
-RUN conda install -c conda-forge ffmpeg
-RUN conda install -c conda-forge pyproj
-RUN conda install -c conda-forge rasterio
+RUN conda install -c conda-forge \
+  xarray
+  netcdf4
+  netcdf4-fortran
+  cartopy
+  ffmpeg
+  pyproj
+  rasterio
 
 # Start container as this user
 USER jovyan
-    

--- a/Dockerfile_v5.6.1_geoclaw
+++ b/Dockerfile_v5.6.1_geoclaw
@@ -8,7 +8,7 @@ USER jovyan
 RUN conda install -c conda-forge \
   xarray \
   netcdf4 \
-  netcdf4-fortran \
+  netcdf-fortran \
   cartopy \
   ffmpeg \
   pyproj \

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 
 To build an image give a command like this in this directory:
 
-    $ docker build -t clawpack/v5.4.1_dockerimage -f Dockerfile_v5.4.1 .
+    $ docker build -t clawpack/v5.6.1_dockerimage -f Dockerfile_v5.6.1 .
 
 To push to [https://hub.docker.com/u/clawpack/dashboard/](dockerhub):
 
     $ docker login
-    $ docker push clawpack/v5.4.1_dockerimage
+    $ docker push clawpack/v5.6.1_dockerimage
+    $ docker tag clawpack/v5.6.1_dockerimage:latest \
+                 clawpack/v5.6.1_dockerimage:release
 
 (Requires an account with with push permission.)
 


### PR DESCRIPTION
@bolliger32, @mandli:  I am trying to make a version `Dockerfile_v5.6.1_geoclaw` that also installs things needed for GeoClaw.  The draft included in this PR installs the Python tools fine, including `netCDF4` so e.g. this works:
```
from clawpack.geoclaw import topotools
topo = topotools.read_netcdf('etopo1',extent=[-123,-122,47,48])
```
But the Fortran code in `geoclaw/tests/netcdf_topo` fails to compile, naturally, since the environment variable `NETCDF4_DIR` isn't set, and probably the fortran version isn't even installed.

Questions:
 1. Is the approach in https://github.com/clawpack/docker-files/blob/master/Dockerfile_v5.4.1_netcdf still the best way to install the fortran, and if so how does this change since I am starting with `FROM clawpack/v5.6.1_dockerimage:release`?
2. How should the environment variable `NETCDF4_DIR` be set?
