### PR TITLE
Add vtk to dockerfile

### DIFF
--- a/Dockerfile_v5.7.0
+++ b/Dockerfile_v5.7.0
@@ -17,7 +17,8 @@ RUN conda install -y -c conda-forge \
   git \
   tar \
   curl \
-  nose
+  nose \
+  vtk
 
 # set env variables
 ENV CLAW ${HOME}/clawpack-v5.7.0


### PR DESCRIPTION
This PR adds vtk, installed via conda-forge, to the 5.7.0 dockerfile. 

This dependency is/was added to pyclaw in clawpack/pyclaw/pull/644 which adds the `vtk.write` function. 

[link to vtk distribution on conda-forge](https://anaconda.org/conda-forge/vtk)  

I note that I have zero experience creating/testing/maintaining dockerfiles. I think I've done this correctly (as it just adds the single conda  dependency to the existing list of other conda dependencies). But if there is a way I should test this, LMK and I'll try.  