### PR TITLE
Add Dockerfile_v5.7.1

### DIFF
--- a/Dockerfile_v5.7.1
+++ b/Dockerfile_v5.7.1
@@ -1,0 +1,39 @@
+# Start from the clawpack v5.7.0 image that includes everything already done
+# in Dockerfile_v5.7.0:
+FROM clawpack/v5.7.0_dockerimage:release
+
+USER jovyan
+
+# upgrade to v5.7.1:
+
+# Install clawpack-v5.7.1:
+RUN pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.7.1#egg=clawpack-v5.7.1
+
+ENV CLAW ${HOME}/clawpack-v5.7.1
+
+# Install additional useful packages
+
+RUN conda install -c conda-forge \
+  xarray \
+  ffmpeg
+
+# Install additional packages useful with GeoClaw:
+
+RUN conda install -c conda-forge \
+  netcdf4 \
+  netcdf-fortran \
+  cartopy \
+  pyproj \
+  rasterio
+
+WORKDIR ${CLAW}
+# Clone the apps repository (with master checked out):
+RUN git clone https://github.com/clawpack/apps.git 
+
+WORKDIR ${HOME}
+
+# fix a few things for git:
+RUN git config --file .gitconfig core.pager more
+RUN git config --file .gitconfig core.editor vim
+
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 To build an image give a command like this in this directory:
 
-    $ docker build -t clawpack/v5.7.0_dockerimage -f Dockerfile_v5.7.0 .
+    $ docker build -t clawpack/v5.7.1_dockerimage -f Dockerfile_v5.7.1 .
 
 To push to [https://hub.docker.com/u/clawpack/dashboard/](dockerhub):
 
     $ docker login
-    $ docker tag clawpack/v5.7.0_dockerimage:latest \
-                 clawpack/v5.7.0_dockerimage:release
-    $ docker push clawpack/v5.7.0_dockerimage:release
+    $ docker tag clawpack/v5.7.1_dockerimage:latest \
+                 clawpack/v5.7.1_dockerimage:release
+    $ docker push clawpack/v5.7.1_dockerimage:release
 
 (Requires an account with with push permission.)
 


### PR DESCRIPTION
Note, I based it on `clawpack/v5.7.0_dockerimage:release` because
the `pip install clawpack` kept giving errors when trying to start
from scratch.  Seems to be some problem with gfortran and f2py, maybe in
`jupyter/base-notebook`?

I also merged in the packages needed for GeoClaw so there is only
one version, rather than a separate geoclaw version.

The apps repository is now cloned, rather than downloading a tar file
that seemed to be out of date.