### PR TITLE
WIP: Dockerfile_v5.8.0, docker fails on pip install clawpack

### DIFF
--- a/Dockerfile_v5.8.0
+++ b/Dockerfile_v5.8.0
@@ -1,0 +1,59 @@
+# Install anaconda Python stack and some other useful tools
+FROM jupyter/base-notebook
+
+USER root
+RUN apt-get update && \
+  apt-get install -y dialog net-tools build-essential
+USER jovyan
+
+
+# Install various things
+RUN conda update -n base conda
+RUN conda install -y -c conda-forge \
+  scipy \
+  compilers \
+  lapack \
+  vim \
+  nano \
+  git \
+  tar \
+  curl \
+  nose \
+  xarray \
+  ffmpeg
+
+# Install additional packages useful with GeoClaw:
+
+RUN conda install -c conda-forge \
+  netcdf4 \
+  netcdf-fortran \
+  cartopy \
+  pyproj \
+  rasterio
+
+# set env variables
+ENV CLAW ${HOME}/clawpack-v5.8.0
+ENV NETCDF4_DIR /opt/conda
+ENV FC gfortran
+# this is needed to find libraries when building geoclaw (particularly lapack)
+ENV LIB_PATHS /opt/conda/lib
+
+# Install clawpack-v5.8.0:
+RUN pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.8.0#egg=clawpack-v5.8.0
+
+# set prompt:
+RUN echo 'export PS1="jovyan $ "' >> ~/.bashrc
+
+WORKDIR ${CLAW}
+# Download the master branch of the apps repository and rename:
+# (You can change `master` to a commit hash for a different version)
+RUN curl -sL https://github.com/clawpack/apps/archive/master.tar.gz | tar xz
+RUN mv apps-* apps
+
+WORKDIR ${HOME}
+
+# fix a few things for git:
+RUN git config --file .gitconfig core.pager more
+RUN git config --file .gitconfig core.editor vim
+
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Tries to change `clawpack-v5.8.0` to `clawpack-v5-8-0` and complains that metadata just says `clawpack`:
```
   ... egg=clawpack-v5.8.0 has inconsistent name: filename has 'clawpack-v5-8-0', but metadata has 'clawpack'
```
I haven't run into this before, and pip install works fine on my laptop.

Any ideas how to fix this?

Here's the error in context...

```
Step 12/20 : RUN pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.8.0#egg=clawpack-v5.8.0
 ---> Running in ac643ef45ab3
Obtaining clawpack-v5.8.0 from git+https://github.com/clawpack/clawpack.git@v5.8.0#egg=clawpack-v5.8.0
  Cloning https://github.com/clawpack/clawpack.git (to revision v5.8.0) to //home/jovyan/clawpack-v5-8-0
  Running command git clone -q https://github.com/clawpack/clawpack.git //home/jovyan/clawpack-v5-8-0
  Running command git submodule update --init --recursive -q
  WARNING: Generating metadata for package clawpack-v5.8.0 produced metadata for project name clawpack. Fix your #egg=clawpack-v5.8.0 fragments.
WARNING: Discarding git+https://github.com/clawpack/clawpack.git@v5.8.0#egg=clawpack-v5.8.0. Requested clawpack from git+https://github.com/clawpack/clawpack.git@v5.8.0#egg=clawpack-v5.8.0 has inconsistent name: filename has 'clawpack-v5-8-0', but metadata has 'clawpack'
ERROR: Could not find a version that satisfies the requirement clawpack-v5-8-0 (unavailable)
ERROR: No matching distribution found for clawpack-v5-8-0 (unavailable)
The command '/bin/sh -c pip install --src=/${HOME}/ --user -e git+https://github.com/clawpack/clawpack.git@v5.8.0#egg=clawpack-v5.8.0' returned a non-zero code: 1

```